### PR TITLE
Restore stdout/stderr during shutdown.

### DIFF
--- a/locust/log.py
+++ b/locust/log.py
@@ -15,6 +15,12 @@ def setup_logging(loglevel, logfile):
     sys.stderr = StdErrWrapper()
     sys.stdout = StdOutWrapper()
 
+
+def restore_std_streams():
+    sys.stderr = sys.__stderr__
+    sys.stdout = sys.__stdout__
+
+
 stdout_logger = logging.getLogger("stdout")
 stderr_logger = logging.getLogger("stderr")
 

--- a/locust/main.py
+++ b/locust/main.py
@@ -14,7 +14,7 @@ import locust
 from . import events, runners, web
 from .core import HttpLocust, Locust
 from .inspectlocust import get_task_ratio_dict, print_task_ratio
-from .log import console_logger, setup_logging
+from .log import console_logger, setup_logging, restore_std_streams
 from .runners import LocalLocustRunner, MasterLocustRunner, SlaveLocustRunner
 from .stats import (print_error_report, print_percentile_stats, print_stats,
                     stats_printer, stats_writer, write_stat_csvs)
@@ -647,7 +647,8 @@ def run_locust(options, arguments=[], cli_mode=False):
         if options.csvfilebase:
             write_stat_csvs(options.csvfilebase)
         print_error_report()
-    
+        restore_std_streams()
+
     # install SIGTERM handler
     def sig_term_handler():
         logger.info("Got SIGTERM signal")


### PR DESCRIPTION
This allows for programs that invoke locust programatically to continue to
operate in a non-surprising fashion after the locus call has completed.